### PR TITLE
Allow script to be re-run efficiently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          components: clippy, rustfmt
+          override: true
+    - name: rustfmt
+      uses: mbrobbel/rustfmt-check@0.2.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: clippy
+      uses: actions-rs/clippy-check@v1.0.5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -47,6 +65,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -145,6 +174,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "console"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,8 +239,11 @@ dependencies = [
  "futures",
  "governor",
  "indicatif",
+ "log",
+ "pretty_env_logger",
  "reqwest",
  "serde",
+ "structopt",
  "tokio",
 ]
 
@@ -251,6 +298,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -462,6 +522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +571,15 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hyper"
@@ -913,6 +991,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1054,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1007,7 +1125,10 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
@@ -1231,6 +1352,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1423,24 @@ checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1455,6 +1633,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1772,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ dotenv = "0.15"
 futures = "0.3.12"
 governor = "0.3.2"
 indicatif = { version = "0.15.0", features = ["improved_unicode"] }
+log = "0.4.14"
+pretty_env_logger = "0.4.0"
 reqwest = { version = "0.11", features = ["rustls-tls", "json", "gzip", "brotli"] }
 serde = { version = "1.0", features = ["derive"] }
+structopt = "0.3.21"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+
+[profile.release]
+lto = "thin"
+panic = "abort"

--- a/README.md
+++ b/README.md
@@ -42,22 +42,30 @@ This repo contains a Rust crate that scrapes data from the NYT's servers. To use
 and then run the following to generate a CSV file containing the data:
 
 ```sh
-NYT_S=<your token> NYT_XWORD_START=YYYY-MM-DD cargo run --release
+# See help screen
+$ cargo run --release -- --help
+
+# Example usage starting search from the crossword on January 1, 2016 onward
+$ cargo run --release -- -t <your NYT token> -s 2016-01-01 -o data.csv
+
+# Example usage using cached data from a previous run to reduce the number of new requests made
+$ cargo run --release -- -t <your NYT token> -s 2016-01-01 -c old_data.csv -o new_data.csv
+
+# Example usage with increased quota to speed up rate-limiting by a factor of 2
+$ cargo run --release -- -t <your NYT token> -s 2016-01-01 -q 10 -o data.csv
 ```
 
-Environment variable definitions:
-* `NYT_S` is your subscription token (see below).
-* `NYT_XWORD_START` is the earliest date to start searching from.
-* `NYT_REQUESTS_PER_SEC` (optional) rate limit for requests
+The NYT subscription token must be extracted via your browser (see below).
 
-By default, the program will limit requests to 5 per second in an attempt to avoid spamming the NYT's servers.
+The program will fetch results concurrently, but by default, requests are limited to 5 per second in an attempt to avoid spamming the NYT's servers.
 While you can choose to override that limit to speed up the search, be nice and use something reasonable.
-This is meant to be a one-off script so it's better to just err on the side of being slow.
-Regardless of what you choose, I'm not responsible for anything that happens to your account.
+There shouldn't be any need to run this script very often so it's better to just err on the side of being slow.
+Regardless of the setting you use, default or not, I'm not responsible for anything that happens to your account.
 
 ### Under the hood
 
-The script hits some undocumented but public REST APIs to scrape data. These APIs can be found by using the included set of developer tools in Chrome or Firefox to peek at HTTP traffic while browsing the crossword webpage.
+The script scrapes data using some undocumented but public REST APIs used by the official NYT crossword webpage.
+The APIs can be found by using the included set of developer tools in Chrome or Firefox to peek at HTTP traffic while browsing the crossword webpage.
 
 Some details if you want to bypass the script and replicate the functionality yourself:
 
@@ -93,7 +101,6 @@ works great.
 ## TODO
 
 * Add plotting code
-* Allow caching of results so that the script can be run regularly
 * Run script regularly
 
 ## References

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Scraping NYT crossword stats ⬛⬜⬜⬜⬜⬛
 
+[![build status](https://img.shields.io/github/workflow/status/kesyog/crossword/Build?style=flat-square)](https://github.com/kesyog/crossword/actions/workflows/build.yml)
+[![Apache 2.0 license](https://img.shields.io/github/license/kesyog/crossword?style=flat-square)](./LICENSE)
+
 When I first subscribed to the _New York Times_ crossword in January 2017, I could solve some Monday
 puzzles and maybe the occasional Tuesday. Over time, I slowly got better at noticing the common
 patterns and picked up enough [crosswordese](https://en.wikipedia.org/wiki/Crosswordese) to be able

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,116 @@
+use crate::api_client::SolvedPuzzleStats;
+use anyhow::{Context, Result};
+use chrono::{naive::NaiveDate, Datelike, Duration, Weekday};
+use serde::{Deserialize, Serialize};
+use std::cmp;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Deserialize, Serialize)]
+pub struct PuzzleStats {
+    pub date: NaiveDate,
+    weekday: Weekday,
+    // It would be nice to embed SolvedPuzzleStats here, but serde's flatten attribute doesn't play
+    // well with the csv crate
+    solve_time_secs: u32,
+    opened_unix: Option<u32>,
+    solved_unix: Option<u32>,
+}
+
+impl PuzzleStats {
+    pub fn new(date: NaiveDate, solve_stats: SolvedPuzzleStats) -> Self {
+        let weekday = date.weekday();
+        Self {
+            date,
+            weekday,
+            solve_time_secs: solve_stats.solve_time,
+            opened_unix: solve_stats.opened,
+            solved_unix: solve_stats.solved,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Database {
+    records: Vec<PuzzleStats>,
+    // The csv crate's Writer will add a header row using struct fieldnames by default
+    writer: Option<csv::Writer<File>>,
+}
+
+impl Database {
+    pub fn new<T: AsRef<Path>>(output: T) -> Self {
+        Self {
+            records: Vec::new(),
+            writer: Some(csv::Writer::from_path(output).unwrap()),
+        }
+    }
+
+    pub fn from_file<T: AsRef<Path>, U: AsRef<Path>>(input: T, output: U) -> Result<Self> {
+        let input = input.as_ref();
+        let file = File::open(input)
+            .with_context(|| format!("Failed to open {}", input.to_str().unwrap()))?;
+        let records = deserialize_records(file)?;
+        let mut writer = csv::Writer::from_path(output)?;
+        for record in &records {
+            writer.serialize(record)?;
+        }
+        writer.flush().expect("Flush error");
+        Ok(Self {
+            records,
+            writer: Some(writer),
+        })
+    }
+
+    pub fn search_space(
+        &self,
+        start: NaiveDate,
+        end: NaiveDate,
+        max_step: u32,
+    ) -> Vec<Vec<NaiveDate>> {
+        let cache: HashSet<NaiveDate> = self.records.iter().map(|stats| stats.date).collect();
+        let mut search_space: Vec<Vec<NaiveDate>> = Vec::new();
+        let mut current_start = start;
+        while current_start <= end {
+            // Find next uncached date in range on or after current_start
+            current_start = match current_start
+                .iter_days()
+                .take_while(|date| *date <= end)
+                .find(|date| !cache.contains(date))
+            {
+                Some(date) => date,
+                None => break,
+            };
+            let current_end =
+                cmp::min(end, current_start + Duration::days(i64::from(max_step) - 1));
+            // Filter any days that have already been cached out of the search block
+            let search_block: Vec<NaiveDate> = current_start
+                .iter_days()
+                .take_while(|date| *date <= current_end)
+                .filter(|date| !cache.contains(date))
+                .collect();
+            search_space.push(search_block);
+            current_start = current_end + Duration::days(1);
+        }
+
+        search_space
+    }
+
+    pub fn add(&mut self, puzzle: PuzzleStats) {
+        if let Some(writer) = self.writer.as_mut() {
+            writer.serialize(puzzle).expect("Serialization error");
+        }
+        self.records.push(puzzle);
+    }
+}
+
+fn deserialize_records<R: Read>(reader: R) -> Result<Vec<PuzzleStats>> {
+    let reader = csv::Reader::from_reader(reader);
+    let mut records: Vec<PuzzleStats> = Vec::new();
+    for record in reader.into_deserialize() {
+        records.push(record.with_context(|| "Malformed record")?);
+    }
+
+    Ok(records)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,56 +13,186 @@
 // limitations under the License.
 
 mod api_client;
+mod database;
 mod logger;
 
 use anyhow::Result;
 use api_client::RateLimitedClient;
 use chrono::naive::NaiveDate;
-use chrono::Duration;
+use core::num::NonZeroU32;
+use database::{Database, PuzzleStats};
 use futures::future;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::cmp;
-use std::convert::{From, Into, TryInto};
+use log::{debug, error, warn};
+use std::convert::TryInto;
+use std::path::PathBuf;
+use structopt::StructOpt;
 use tokio::sync::mpsc;
 
 // Size of each block of dates to fetch metadata about. Currently hard-coded to match the expected
 // server response with no validation that this is correct.
 const DAY_STEP: u32 = 100;
 
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// NYT subscription token extracted from web browser
+    #[structopt(short = "t", long = "token", env = "NYT_S")]
+    nyt_token: String,
+
+    /// Earliest puzzle date to pull results from in YYYY-MM-DD format
+    #[structopt(short, long, env = "NYT_XWORD_START")]
+    start_date: NaiveDate,
+
+    /// Rate-limit (per second) for outgoing requests
+    #[structopt(
+        short = "q",
+        long = "quota",
+        default_value = "5",
+        env = "NYT_REQUESTS_PER_SEC"
+    )]
+    request_quota: NonZeroU32,
+
+    /// Path to data from a previous program run ot use as a cache. If provided, results will only
+    /// be fetched for puzzles that aren't already in the cache.
+    #[structopt(short = "c", long = "cache")]
+    input_file: Option<PathBuf>,
+
+    /// Path to write CSV output. Can be the same as `input_file`
+    output_file: PathBuf,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
+    pretty_env_logger::init();
+    let opt = Opt::from_args();
+
     let today = chrono::offset::Utc::today().naive_utc();
-    let start_date_str = dotenv::var("NYT_XWORD_START").expect("Provide search start date in YYYY-MM-DD format as an environment variable named NYT_XWORD_START.");
-    let start_date: NaiveDate = start_date_str
-        .parse()
-        .expect("Start date parse error. Please provide date in YYYY-MM-DD format.");
-    let total_days = (today - start_date + Duration::days(1)).num_days();
+    let stats_db = match opt.input_file {
+        Some(input) => Database::from_file(input, &opt.output_file).unwrap(),
+        None => Database::new(&opt.output_file),
+    };
+    let search_space = stats_db.search_space(opt.start_date, today, DAY_STEP);
+
+    let total_days: usize = search_space.iter().map(Vec::len).sum();
     let progress = ProgressBar::new(total_days.try_into().unwrap()).with_style(
         ProgressStyle::default_bar()
             .template("▕{bar:40}▏{eta} {percent}% {msg}")
             .progress_chars("⬛🔲⬜"),
     );
-    progress.println(["Fetching NYT crossword stats since ", &start_date_str].join(""));
+    progress.println(
+        [
+            "Fetching NYT crossword stats since",
+            &opt.start_date.to_string(),
+        ]
+        .join(" "),
+    );
 
     let (tx, rx) = mpsc::unbounded_channel();
-    let logger_handle = tokio::spawn(logger::task_fn(rx, progress));
+    let logger_handle = tokio::spawn(logger::task_fn(rx, stats_db, progress));
 
-    let client = RateLimitedClient::new();
+    let client = RateLimitedClient::new(&opt.nyt_token, opt.request_quota);
+    if let Err(e) = fetch_stats(client, search_space, tx.clone()).await {
+        error!("fetch_stats returned error: {}", e);
+    };
+    tx.send(logger::Payload::Finished)?;
+    logger_handle.await??;
+    Ok(())
+}
+
+/// Concurrently fetch statistics for the crosswords from the given dates and send the results to
+/// the provided channel
+///
+/// # Arguments
+///
+/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
+/// * `dates` - Blocks of dates to search. Each block must be sorted and contain no more than
+/// `DAY_STEP` elements
+/// * `logger` - Channel where individual puzzle's statistics should be sent to
+async fn fetch_stats(
+    client: RateLimitedClient,
+    dates: Vec<Vec<NaiveDate>>,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
     let mut futures = Vec::new();
-    let mut date = start_date;
-    while date <= today {
-        let end_date = cmp::min(today, date + Duration::days(i64::from(DAY_STEP) - 1));
+    for block_of_dates in dates {
         futures.push(tokio::spawn({
             let client = client.clone();
-            let tx = tx.clone();
-            async move { client.search_dates(date, end_date, tx).await }
+            let tx = logger.clone();
+            async move { search_date_block(client, block_of_dates, tx).await }
         }));
-        date += Duration::days(DAY_STEP.into());
     }
 
     future::join_all(futures).await;
-    tx.send(logger::Payload::Finished)?;
-    logger_handle.await??;
+    Ok(())
+}
+
+/// Concurrently search crosswords within the provided block of dates and send the results to the
+/// provided channel
+///
+/// # Arguments
+///
+/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
+/// * `block_of_dates` - Sorted list of puzzle dates to search. Must contain no more than
+/// `DAY_STEP` elements
+/// * `logger` - Channel where individual puzzle's statistics should be sent to
+async fn search_date_block(
+    client: RateLimitedClient,
+    block_of_dates: Vec<NaiveDate>,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
+    assert!(block_of_dates.len() <= DAY_STEP.try_into().unwrap());
+    let start = block_of_dates[0];
+    let end = *block_of_dates.iter().last().unwrap();
+
+    debug!("Fetching ids for date range {} to {}", start, end);
+    let id_map = match client.get_puzzle_ids(start, end).await {
+        Ok(map) => map,
+        Err(e) => {
+            // This may occur if the entire date block consists of unreleased puzzles, which would
+            // happen if the puzzle from the last date in the search block (today in UTC) hasn't
+            // been released yet.
+            warn!(
+                "Couldn't get puzzle id for date range {} to {}. Error: {:?}",
+                start, end, e
+            );
+            return Ok(());
+        }
+    };
+
+    // Concurrently find stats for all puzzles in block
+    let mut futures = Vec::new();
+    for date in block_of_dates {
+        let id = if let Some(id) = id_map.get(&date) {
+            *id
+        } else {
+            // This will occur if there are unreleased puzzles in this date block
+            warn!("No id found for {}", date);
+            continue;
+        };
+        futures.push(tokio::spawn({
+            let client = client.clone();
+            let logger = logger.clone();
+            async move {
+                match client.get_solve_stats(id).await {
+                    Ok(Some(solve_stats)) => {
+                        logger
+                            .send(logger::Payload::Solve(PuzzleStats::new(date, solve_stats)))
+                            .expect("Failed to send result to channel");
+                    }
+                    Ok(None) => logger
+                        .send(logger::Payload::Unsolved)
+                        .expect("Failed to send result to channel"),
+                    Err(e) => {
+                        error!("Failed to get stats for date={} id={}: {}", date, id, e);
+                        logger
+                            .send(logger::Payload::FetchError)
+                            .expect("Failed to send result to channel");
+                    }
+                }
+            }
+        }));
+    }
+    future::join_all(futures).await;
     Ok(())
 }


### PR DESCRIPTION
 #### Issues Addressed

 Ultimately, I want to run the script regularly so that an updated plot
 can be generated daily. However, the program re-fetched all puzzle data
 on every iteration, which is wasteful and poor behavior.

 #### Summary of Changes

 * Allow loading of existing data to reduce the number of requests needed
 for subsequent program runs
   * Add database abstraction to store puzzle stats and load
 previously-stored data from file. The database continues to be backed by
 a CSV file under the hood, but switching it out to something else later
 should now be simpler.
   * Add function to calculate the minimal search space to query puzzle
 statistics for, skipping any dates that are already in the database.
 Once this is properly hooked in, the entire puzzle history doesn't need
 to re-fetched on every run, greatly reducing the number of requests
 needed for incremental updates.
 * Allow parameters to be set via arguments using `structopt` crate rather
 than relying on environment variables
 * Add logging via `pretty_env_logger` and `log` crates
 * Bug fixes
   * Add connect timeout to reqwest client
   * Increase concurrency of puzzle data fetching. Some operations were
 unintentionally being serialized.
