### PR TITLE
📓 Minimize re-requests by storing data for unsolved and aided puzzles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "reqwest",
  "serde",
  "structopt",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,5 @@ serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3.21"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 
-[profile.release]
-lto = "thin"
-panic = "abort"
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -46,21 +46,27 @@ and then run the following to generate a CSV file containing the data:
 $ cargo run --release -- --help
 
 # Example usage starting search from the crossword on January 1, 2016 onward
-$ cargo run --release -- -t <your NYT token> -s 2016-01-01 -o data.csv
+# Subsequent program runs will use existing file as a cache 
+$ cargo run --release -- -t <your NYT token> -s 2016-01-01 data.csv
 
-# Example usage using cached data from a previous run to reduce the number of new requests made
-$ cargo run --release -- -t <your NYT token> -s 2016-01-01 -c old_data.csv -o new_data.csv
-
-# Example usage with increased quota to speed up rate-limiting by a factor of 2
+# Example usage with increased quota to set rate-limit to 10 requests/second
 $ cargo run --release -- -t <your NYT token> -s 2016-01-01 -q 10 -o data.csv
 ```
 
 The NYT subscription token must be extracted via your browser (see below).
 
-The program will fetch results concurrently, but by default, requests are limited to 5 per second in an attempt to avoid spamming the NYT's servers.
+The program will fetch results concurrently, but by default, requests are limited to 5 per second to reduce the load on NYT's servers.
 While you can choose to override that limit to speed up the search, be nice and use something reasonable.
 There shouldn't be any need to run this script very often so it's better to just err on the side of being slow.
 Regardless of the setting you use, default or not, I'm not responsible for anything that happens to your account.
+
+### Design goals
+
+1. Reduce requests made to NYT's servers. If provided, data from previous runs is loaded and used to
+avoid re-requesting information pulled from previous runs.
+2. Reduce load on NYT's servers. Requests made to the server are rate-limited.
+3. Maximum concurrency. Requests are made as concurrently as possible given the other two
+constraints thanks to async/await. It's totally overkill with the default amount of rate-limiting 🤷🏽‍♂
 
 ### Under the hood
 
@@ -101,7 +107,6 @@ works great.
 ## TODO
 
 * Add plotting code
-* Run script regularly
 
 ## References
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -11,23 +11,27 @@ use std::path::Path;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Deserialize, Serialize)]
 pub struct PuzzleStats {
     pub date: NaiveDate,
+    /// id used to identify a puzzle to NYT server
+    /// TODO: consider removing Option wrapper once database has been fully updated with ids
+    puzzle_id: Option<u32>,
     weekday: Weekday,
     // It would be nice to embed SolvedPuzzleStats here, but serde's flatten attribute doesn't play
     // well with the csv crate
-    solve_time_secs: u32,
+    solve_time_secs: Option<u32>,
     opened_unix: Option<u32>,
     solved_unix: Option<u32>,
 }
 
 impl PuzzleStats {
-    pub fn new(date: NaiveDate, solve_stats: SolvedPuzzleStats) -> Self {
+    pub fn new(date: NaiveDate, id: u32, solve_stats: Option<SolvedPuzzleStats>) -> Self {
         let weekday = date.weekday();
         Self {
             date,
+            puzzle_id: Some(id),
             weekday,
-            solve_time_secs: solve_stats.solve_time,
-            opened_unix: solve_stats.opened,
-            solved_unix: solve_stats.solved,
+            solve_time_secs: solve_stats.map(|s| s.solve_time),
+            opened_unix: solve_stats.and_then(|s| s.opened),
+            solved_unix: solve_stats.and_then(|s| s.solved),
         }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,9 +1,23 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::api_client::SolvedPuzzleStats;
 use anyhow::{Context, Result};
-use chrono::{naive::NaiveDate, Datelike, Duration, Weekday};
+use chrono::{naive::NaiveDate, Datelike, Weekday};
+use log::{error, warn};
 use serde::{Deserialize, Serialize};
-use std::cmp;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -13,11 +27,11 @@ pub struct PuzzleStats {
     pub date: NaiveDate,
     /// id used to identify a puzzle to NYT server
     /// TODO: consider removing Option wrapper once database has been fully updated with ids
-    puzzle_id: Option<u32>,
+    pub puzzle_id: Option<u32>,
     weekday: Weekday,
     // It would be nice to embed SolvedPuzzleStats here, but serde's flatten attribute doesn't play
     // well with the csv crate
-    solve_time_secs: Option<u32>,
+    pub solve_time_secs: Option<u32>,
     opened_unix: Option<u32>,
     solved_unix: Option<u32>,
 }
@@ -34,22 +48,46 @@ impl PuzzleStats {
             solved_unix: solve_stats.and_then(|s| s.solved),
         }
     }
+
+    pub fn empty(date: NaiveDate) -> Self {
+        let weekday = date.weekday();
+        Self {
+            date,
+            weekday,
+            puzzle_id: None,
+            solve_time_secs: None,
+            opened_unix: None,
+            solved_unix: None,
+        }
+    }
+
+    pub const fn is_complete(&self) -> bool {
+        matches!((self.puzzle_id, self.solve_time_secs), (Some(_), Some(_)))
+    }
+
+    pub fn update_stats(&mut self, stats: SolvedPuzzleStats) {
+        self.solve_time_secs = Some(stats.solve_time);
+        self.opened_unix = stats.opened;
+        self.solved_unix = stats.solved;
+    }
 }
 
 #[derive(Debug)]
 pub struct Database {
-    records: Vec<PuzzleStats>,
+    records: HashMap<NaiveDate, PuzzleStats>,
     filepath: PathBuf,
 }
 
 impl Database {
+    /// Create a new database at the given path
     pub fn new<T: Into<PathBuf>>(out_path: T) -> Self {
         Self {
-            records: Vec::new(),
+            records: HashMap::new(),
             filepath: out_path.into(),
         }
     }
 
+    /// Load a database from file
     pub fn from_file<T: AsRef<Path>>(path: T) -> Result<Self> {
         let path = path.as_ref();
         let file = File::open(path)
@@ -61,48 +99,28 @@ impl Database {
         })
     }
 
-    pub fn search_space(
-        &self,
-        start: NaiveDate,
-        end: NaiveDate,
-        max_step: u32,
-    ) -> Vec<Vec<NaiveDate>> {
-        let cache: HashSet<NaiveDate> = self.records.iter().map(|stats| stats.date).collect();
-        let mut search_space: Vec<Vec<NaiveDate>> = Vec::new();
-        let mut current_start = start;
-        while current_start <= end {
-            // Find next uncached date in range on or after current_start
-            current_start = match current_start
-                .iter_days()
-                .take_while(|date| *date <= end)
-                .find(|date| !cache.contains(date))
-            {
-                Some(date) => date,
-                None => break,
-            };
-            let current_end =
-                cmp::min(end, current_start + Duration::days(i64::from(max_step) - 1));
-            // Filter any days that have already been cached out of the search block
-            let search_block: Vec<NaiveDate> = current_start
-                .iter_days()
-                .take_while(|date| *date <= current_end)
-                .filter(|date| !cache.contains(date))
-                .collect();
-            search_space.push(search_block);
-            current_start = current_end + Duration::days(1);
-        }
-
-        search_space
+    pub fn records(&self) -> Vec<PuzzleStats> {
+        self.records.values().copied().collect()
     }
 
+    pub fn get(&self, date: NaiveDate) -> Option<PuzzleStats> {
+        self.records.get(&date).copied()
+    }
+
+    pub fn contains(&self, date: NaiveDate) -> bool {
+        self.records.contains_key(&date)
+    }
+
+    /// Add record to database. If a record already exists for the given date, it will be
+    /// overwritten
     pub fn add(&mut self, puzzle: PuzzleStats) {
-        self.records.push(puzzle);
+        self.records.insert(puzzle.date, puzzle);
     }
 
     /// Write database to file
     pub fn flush(&self) -> Result<()> {
         let mut writer = csv::Writer::from_path(&self.filepath)?;
-        let mut sorted = self.records.clone();
+        let mut sorted = self.records.values().copied().collect::<Vec<PuzzleStats>>();
         sorted.sort_unstable_by_key(|s| s.date);
 
         // The csv crate's Writer will add a header row using struct fieldnames by default
@@ -113,11 +131,22 @@ impl Database {
     }
 }
 
-fn deserialize_records<R: Read>(reader: R) -> Result<Vec<PuzzleStats>> {
+impl Drop for Database {
+    fn drop(&mut self) {
+        if let Err(e) = self.flush() {
+            error!("Error flushing database: {}", e);
+        }
+    }
+}
+
+fn deserialize_records<R: Read>(reader: R) -> Result<HashMap<NaiveDate, PuzzleStats>> {
     let reader = csv::Reader::from_reader(reader);
-    let mut records: Vec<PuzzleStats> = Vec::new();
+    let mut records = HashMap::new();
     for record in reader.into_deserialize() {
-        records.push(record.with_context(|| "Malformed record")?);
+        let record: PuzzleStats = record.with_context(|| "Malformed record")?;
+        if records.insert(record.date, record).is_some() {
+            warn!("Duplicate record in loaded database for {}", record.date);
+        }
     }
 
     Ok(records)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,159 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod api_client;
+pub mod database;
+pub mod logger;
+pub mod search;
+
+use chrono::{naive::NaiveDate, Duration};
+use database::{Database, PuzzleStats};
+use std::cmp;
+
+// Size of each block of dates to fetch metadata about. Currently hard-coded to match the expected
+// server response with no validation that this is correct.
+pub const DAY_STEP: i64 = 100;
+
+/// Get records within the given range, inclusive, that are missing ids, including for days that
+/// are not present in the database. The results are split into chunks no more than
+/// `max_chunk_duration` long for convenience, as the NYT id APIs allow batched lookup of ids.
+#[must_use]
+pub fn get_days_without_ids_chunked(
+    database: &Database,
+    start: NaiveDate,
+    end: NaiveDate,
+    max_chunk_duration: Duration,
+) -> Vec<Vec<PuzzleStats>> {
+    let mut chunks: Vec<Vec<PuzzleStats>> = Vec::new();
+    let mut current_start = start;
+    while current_start <= end {
+        // Find next date in given range on or after current_start that does not have a cached id
+        // in the database
+        current_start = match current_start
+            .iter_days()
+            .take_while(|date| *date <= end)
+            .find(|date| match database.get(*date) {
+                Some(record) => record.puzzle_id.is_none(),
+                None => true,
+            }) {
+            Some(date) => date,
+            None => break,
+        };
+        let current_end = cmp::min(end, current_start + max_chunk_duration - Duration::days(1));
+        // Create a block of stats records that are missing ids
+        let block: Vec<PuzzleStats> = current_start
+            .iter_days()
+            .take_while(|date| *date <= current_end)
+            .filter_map(|date| {
+                if let Some(record) = database.get(date) {
+                    if record.puzzle_id.is_none() {
+                        Some(record)
+                    } else {
+                        None
+                    }
+                } else {
+                    // The date does not exist in the database at all
+                    Some(PuzzleStats::empty(date))
+                }
+            })
+            .collect();
+        chunks.push(block);
+        current_start = current_end + Duration::days(1);
+    }
+
+    chunks
+}
+
+/// Get records from database that have a cached puzzle id but aren't known to be solved
+#[must_use]
+pub fn get_cached_unsolved_records(database: &Database) -> Vec<PuzzleStats> {
+    let mut records = database.records();
+    records.retain(|r| !r.is_complete() && r.puzzle_id.is_some());
+    records
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use api_client::SolvedPuzzleStats;
+    use std::default::Default;
+    use tempfile::NamedTempFile;
+
+    fn contains_date(haystack: &Vec<Vec<PuzzleStats>>, date: NaiveDate) -> bool {
+        haystack
+            .into_iter()
+            .flatten()
+            .any(|record| record.date == date)
+    }
+
+    #[test]
+    /// Test get_days_without_ids_chunked
+    /// TODO: add more test coverage
+    fn days_without_ids() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        let path = file.into_temp_path().to_path_buf();
+        let mut db = Database::new(path);
+        // Empty record
+        let empty_date = NaiveDate::from_ymd(2020, 1, 1);
+        db.add(PuzzleStats::empty(empty_date));
+        // Record with solve stats but without an id
+        let solved_no_id_date = NaiveDate::from_ymd(2020, 1, 2);
+        let mut solved_no_id =
+            PuzzleStats::new(solved_no_id_date, 0, Some(SolvedPuzzleStats::default()));
+        solved_no_id.puzzle_id = None;
+        db.add(solved_no_id);
+        // Record with solve stats and id
+        let solved_ided_date = NaiveDate::from_ymd(2020, 1, 3);
+        db.add(PuzzleStats::new(
+            solved_ided_date,
+            20,
+            Some(SolvedPuzzleStats::default()),
+        ));
+        // Record with no solve stats but with an id
+        let unsolved_ided_date = NaiveDate::from_ymd(2020, 1, 4);
+        db.add(PuzzleStats::new(unsolved_ided_date, 100, None));
+
+        let start = NaiveDate::from_ymd(2020, 1, 1);
+        let end = NaiveDate::from_ymd(2020, 1, 11);
+
+        let chunks = get_days_without_ids_chunked(&db, start, end, Duration::days(5));
+        assert!(
+            contains_date(&chunks, empty_date),
+            "Empty record should be returned"
+        );
+        assert!(
+            contains_date(&chunks, solved_no_id_date),
+            "Solved, no-id record should be returned"
+        );
+        assert!(
+            !contains_date(&chunks, solved_ided_date),
+            "Solved, ided record should not be returned"
+        );
+        assert!(
+            !contains_date(&chunks, unsolved_ided_date),
+            "Unsolved, ided record should not be returned"
+        );
+        assert!(
+            contains_date(&chunks, end),
+            "Ensure end date is returned (if empty)"
+        );
+        assert!(
+            !contains_date(&chunks, end + Duration::days(1)),
+            "The end date should be the last included date"
+        );
+
+        Ok(())
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -34,6 +34,7 @@ pub async fn task_fn(
         match payload {
             Payload::Solve(stats) | Payload::Unsolved(stats) => stats_db.add(stats),
             Payload::Finished(n_requests) => {
+                stats_db.flush()?;
                 let msg = format!("🎉 All done after {} requests", n_requests);
                 progress.finish_with_message(&msg);
                 break;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::database::{Database, PuzzleStats};
+use crate::database::Database;
+use crate::PuzzleStats;
 use anyhow::Result;
 use indicatif::ProgressBar;
 use tokio::sync::mpsc;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -22,7 +22,7 @@ pub enum Payload {
     Solve(PuzzleStats),
     Unsolved(PuzzleStats),
     FetchError,
-    Finished,
+    Finished(u32),
 }
 
 pub async fn task_fn(
@@ -33,8 +33,9 @@ pub async fn task_fn(
     while let Some(payload) = rx.recv().await {
         match payload {
             Payload::Solve(stats) | Payload::Unsolved(stats) => stats_db.add(stats),
-            Payload::Finished => {
-                progress.finish_with_message("All done 🎉");
+            Payload::Finished(n_requests) => {
+                let msg = format!("🎉 All done after {} requests", n_requests);
+                progress.finish_with_message(&msg);
                 break;
             }
             Payload::FetchError => (),

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 #[derive(Debug, Clone, Copy, Hash, PartialEq)]
 pub enum Payload {
     Solve(PuzzleStats),
-    Unsolved,
+    Unsolved(PuzzleStats),
     FetchError,
     Finished,
 }
@@ -32,12 +32,12 @@ pub async fn task_fn(
 ) -> Result<()> {
     while let Some(payload) = rx.recv().await {
         match payload {
-            Payload::Solve(stats) => stats_db.add(stats),
+            Payload::Solve(stats) | Payload::Unsolved(stats) => stats_db.add(stats),
             Payload::Finished => {
                 progress.finish_with_message("All done 🎉");
                 break;
             }
-            Payload::Unsolved | Payload::FetchError => (),
+            Payload::FetchError => (),
         }
         progress.inc(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,26 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod api_client;
-mod database;
-mod logger;
-
 use anyhow::Result;
-use api_client::RateLimitedClient;
-use chrono::naive::NaiveDate;
+use chrono::{naive::NaiveDate, Duration};
 use core::num::NonZeroU32;
-use database::{Database, PuzzleStats};
-use futures::future;
+use crosswords::api_client::RateLimitedClient;
+use crosswords::database::Database;
+use crosswords::{logger, DAY_STEP};
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{debug, error, warn};
+use log::warn;
 use std::convert::TryInto;
 use std::path::PathBuf;
 use structopt::StructOpt;
 use tokio::sync::mpsc;
-
-// Size of each block of dates to fetch metadata about. Currently hard-coded to match the expected
-// server response with no validation that this is correct.
-const DAY_STEP: u32 = 100;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
@@ -70,131 +62,51 @@ async fn main() -> Result<()> {
     } else {
         Database::new(opt.db_path)
     };
-    let search_space = stats_db.search_space(opt.start_date, today, DAY_STEP);
 
-    let total_days: usize = search_space.iter().map(Vec::len).sum();
+    let missing_ids = crosswords::get_days_without_ids_chunked(
+        &stats_db,
+        opt.start_date,
+        today,
+        Duration::days(DAY_STEP),
+    );
+    let cached_unsolved = crosswords::get_cached_unsolved_records(&stats_db);
+
+    let total_days = missing_ids.iter().map(Vec::len).sum::<usize>() + cached_unsolved.len();
     let progress = ProgressBar::new(total_days.try_into().unwrap()).with_style(
         ProgressStyle::default_bar()
             .template("▕{bar:40}▏{eta} {percent}% {msg}")
             .progress_chars("⬛🔲⬜"),
     );
-    progress.println(
-        [
-            "Fetching NYT crossword stats since",
-            &opt.start_date.to_string(),
-        ]
-        .join(" "),
+
+    let msg = format!(
+        "Fetching NYT crossword stats since {}",
+        &opt.start_date.to_string()
     );
+    progress.println(msg);
 
     let (tx, rx) = mpsc::unbounded_channel();
     let logger_handle = tokio::spawn(logger::task_fn(rx, stats_db, progress));
 
     let client = RateLimitedClient::new(&opt.nyt_token, opt.request_quota);
-    if let Err(e) = fetch_stats(client.clone(), search_space, tx.clone()).await {
-        error!("fetch_stats returned error: {}", e);
+
+    let ids_task = tokio::spawn(crosswords::search::fetch_ids_and_stats(
+        client.clone(),
+        missing_ids,
+        tx.clone(),
+    ));
+    let unsolved_task = tokio::spawn(crosswords::search::fetch_missing_times(
+        client.clone(),
+        cached_unsolved,
+        tx.clone(),
+    ));
+
+    if let Err(e) = ids_task.await? {
+        warn!("Error in fetch_ids_and_stats: {}", e);
+    };
+    if let Err(e) = unsolved_task.await? {
+        warn!("Error in fetch_missing_times: {}", e);
     };
     tx.send(logger::Payload::Finished(client.n_requests()))?;
     logger_handle.await??;
-    Ok(())
-}
-
-/// Concurrently fetch statistics for the crosswords from the given dates and send the results to
-/// the provided channel
-///
-/// # Arguments
-///
-/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
-/// * `dates` - Blocks of dates to search. Each block must be sorted and contain no more than
-/// `DAY_STEP` elements
-/// * `logger` - Channel where individual puzzle's statistics should be sent to
-async fn fetch_stats(
-    client: RateLimitedClient,
-    dates: Vec<Vec<NaiveDate>>,
-    logger: mpsc::UnboundedSender<logger::Payload>,
-) -> Result<()> {
-    let mut futures = Vec::new();
-    for block_of_dates in dates {
-        futures.push(tokio::spawn({
-            let client = client.clone();
-            let tx = logger.clone();
-            async move { search_date_block(client, block_of_dates, tx).await }
-        }));
-    }
-
-    future::join_all(futures).await;
-    Ok(())
-}
-
-/// Concurrently search crosswords within the provided block of dates and send the results to the
-/// provided channel
-///
-/// # Arguments
-///
-/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
-/// * `block_of_dates` - Sorted list of puzzle dates to search. Must contain no more than
-/// `DAY_STEP` elements
-/// * `logger` - Channel where individual puzzle's statistics should be sent to
-async fn search_date_block(
-    client: RateLimitedClient,
-    block_of_dates: Vec<NaiveDate>,
-    logger: mpsc::UnboundedSender<logger::Payload>,
-) -> Result<()> {
-    assert!(block_of_dates.len() <= DAY_STEP.try_into().unwrap());
-    let start = block_of_dates[0];
-    let end = *block_of_dates.iter().last().unwrap();
-
-    debug!("Fetching ids for date range {} to {}", start, end);
-    let id_map = match client.get_puzzle_ids(start, end).await {
-        Ok(map) => map,
-        Err(e) => {
-            // This may occur if the entire date block consists of unreleased puzzles, which would
-            // happen if the puzzle from the last date in the search block (today in UTC) hasn't
-            // been released yet.
-            warn!(
-                "Couldn't get puzzle id for date range {} to {}. Error: {:?}",
-                start, end, e
-            );
-            return Ok(());
-        }
-    };
-
-    // Concurrently find stats for all puzzles in block
-    let mut futures = Vec::new();
-    for date in block_of_dates {
-        let id = if let Some(id) = id_map.get(&date) {
-            *id
-        } else {
-            // This will occur if there are unreleased puzzles in this date block
-            warn!("No id found for {}", date);
-            continue;
-        };
-        futures.push(tokio::spawn({
-            let client = client.clone();
-            let logger = logger.clone();
-            async move {
-                match client.get_solve_stats(id).await {
-                    Ok(Some(solve_stats)) => {
-                        let stats = PuzzleStats::new(date, id, Some(solve_stats));
-                        logger
-                            .send(logger::Payload::Solve(stats))
-                            .expect("Failed to send result to channel");
-                    }
-                    Ok(None) => {
-                        let stats = PuzzleStats::new(date, id, None);
-                        logger
-                            .send(logger::Payload::Unsolved(stats))
-                            .expect("Failed to send result to channel");
-                    }
-                    Err(e) => {
-                        error!("Failed to get stats for date={} id={}: {}", date, id, e);
-                        logger
-                            .send(logger::Payload::FetchError)
-                            .expect("Failed to send result to channel");
-                    }
-                }
-            }
-        }));
-    }
-    future::join_all(futures).await;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,10 +92,10 @@ async fn main() -> Result<()> {
     let logger_handle = tokio::spawn(logger::task_fn(rx, stats_db, progress));
 
     let client = RateLimitedClient::new(&opt.nyt_token, opt.request_quota);
-    if let Err(e) = fetch_stats(client, search_space, tx.clone()).await {
+    if let Err(e) = fetch_stats(client.clone(), search_space, tx.clone()).await {
         error!("fetch_stats returned error: {}", e);
     };
-    tx.send(logger::Payload::Finished)?;
+    tx.send(logger::Payload::Finished(client.n_requests()))?;
     logger_handle.await??;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,13 +176,17 @@ async fn search_date_block(
             async move {
                 match client.get_solve_stats(id).await {
                     Ok(Some(solve_stats)) => {
+                        let stats = PuzzleStats::new(date, id, Some(solve_stats));
                         logger
-                            .send(logger::Payload::Solve(PuzzleStats::new(date, solve_stats)))
+                            .send(logger::Payload::Solve(stats))
                             .expect("Failed to send result to channel");
                     }
-                    Ok(None) => logger
-                        .send(logger::Payload::Unsolved)
-                        .expect("Failed to send result to channel"),
+                    Ok(None) => {
+                        let stats = PuzzleStats::new(date, id, None);
+                        logger
+                            .send(logger::Payload::Unsolved(stats))
+                            .expect("Failed to send result to channel");
+                    }
                     Err(e) => {
                         error!("Failed to get stats for date={} id={}: {}", date, id, e);
                         logger

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,155 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::api_client::RateLimitedClient;
+use crate::database::PuzzleStats;
+use crate::logger;
+use anyhow::Result;
+use futures::future;
+use log::{debug, error, warn};
+use std::convert::TryInto;
+use tokio::sync::mpsc;
+
+pub async fn fetch_missing_times(
+    client: RateLimitedClient,
+    dates: Vec<PuzzleStats>,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
+    let mut futures = Vec::new();
+    for puzzle in dates {
+        futures.push(tokio::spawn(get_solve_stats(
+            client.clone(),
+            puzzle,
+            logger.clone(),
+        )));
+    }
+    future::join_all(futures).await;
+    Ok(())
+}
+
+/// Concurrently fetch statistics for the crosswords from the given dates and send the results to
+/// the provided channel
+///
+/// # Arguments
+///
+/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
+/// * `dates` - Blocks of dates to search. Each block must be sorted and contain no more than
+/// `DAY_STEP` elements
+/// * `logger` - Channel where individual puzzle's statistics should be sent to
+pub async fn fetch_ids_and_stats(
+    client: RateLimitedClient,
+    dates: Vec<Vec<PuzzleStats>>,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
+    let mut futures = Vec::new();
+    for block_of_dates in dates {
+        futures.push(tokio::spawn({
+            let client = client.clone();
+            let tx = logger.clone();
+            async move { search_date_block(client, block_of_dates, tx).await }
+        }));
+    }
+
+    future::join_all(futures).await;
+    Ok(())
+}
+
+/// Concurrently search crosswords within the provided block of dates and send the results to the
+/// provided channel
+///
+/// # Arguments
+///
+/// * `client` - A `RateLimitedClient` that can be used to send outgoing requests
+/// * `block_of_dates` - Sorted list of puzzle dates to search. Must contain no more than
+/// `DAY_STEP` elements
+/// * `logger` - Channel where individual puzzle's statistics should be sent to
+async fn search_date_block(
+    client: RateLimitedClient,
+    block: Vec<PuzzleStats>,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
+    assert!(block.len() <= crate::DAY_STEP.try_into().unwrap());
+    let start = block[0].date;
+    let end = block.iter().last().unwrap().date;
+
+    debug!("Fetching ids for date range {} to {}", start, end);
+    let id_map = match client.get_puzzle_ids(start, end).await {
+        Ok(map) => map,
+        Err(e) => {
+            // This may occur if the entire date block consists of unreleased puzzles, which would
+            // happen if the puzzle from the last date in the search block (today in UTC) hasn't
+            // been released yet.
+            warn!(
+                "Couldn't get puzzle id for date range {} to {}. Error: {:?}",
+                start, end, e
+            );
+            return Ok(());
+        }
+    };
+
+    // Concurrently find stats for all puzzles in block
+    let mut futures = Vec::new();
+    for mut puzzle in block {
+        let date = puzzle.date;
+        puzzle.puzzle_id = if let Some(id) = id_map.get(&date) {
+            Some(*id)
+        } else {
+            // This will occur if there are unreleased puzzles in this date block
+            warn!("No id found for {}", date);
+            logger.send(logger::Payload::FetchError(None))?;
+            continue;
+        };
+        // Check if the solve time is already known. This would happen if the loaded database
+        // contained a puzzle record that had a solve time but no saved id
+        if puzzle.solve_time_secs.is_some() {
+            logger.send(logger::Payload::Solve(puzzle)).unwrap();
+            continue;
+        }
+        futures.push(tokio::spawn(get_solve_stats(
+            client.clone(),
+            puzzle,
+            logger.clone(),
+        )));
+    }
+    future::join_all(futures).await;
+    Ok(())
+}
+
+async fn get_solve_stats(
+    client: RateLimitedClient,
+    mut puzzle: PuzzleStats,
+    logger: mpsc::UnboundedSender<logger::Payload>,
+) -> Result<()> {
+    let id = puzzle.puzzle_id.unwrap();
+    match client.get_solve_stats(id).await {
+        Ok(Some(solve_stats)) => {
+            puzzle.update_stats(solve_stats);
+            logger.send(logger::Payload::Solve(puzzle)).unwrap();
+        }
+        Ok(None) => {
+            logger.send(logger::Payload::Unsolved(puzzle)).unwrap();
+        }
+        Err(e) => {
+            error!(
+                "Failed to get stats for date={} id={}: {}",
+                puzzle.date, id, e
+            );
+            // Send puzzle stats to get added to database anyway. At least we know its id.
+            logger
+                .send(logger::Payload::FetchError(Some(puzzle)))
+                .unwrap();
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Issues addressed

Data for unsolved puzzles and puzzles where cheats were used were being unnecessarily re-requested on each program run.

1. Each puzzle has a unique, constant puzzle id on the NYT servers, and the date<->puzzle id mapping for these puzzles was being re-requested on each program iteration.
2. Data for unsolved puzzles needs to be queried on each program iteration to see if they have been newly solved. Puzzles where cheats were used were treated the same as unsolved even though their status won't change in subsequent runs.

### Summary of changes

* Store puzzle id and cheat usage status to the database
* Load cached puzzle id and cheat usage information from the database and only send requests for new data:
  * Puzzle ids for puzzle dates that weren't already in the database or existed without a puzzle id (e.g. because an older version of the database was used)
  * Solve stats for dates that either didn't exist in the database or that existed but were unsolved

#### Tangential changes
* Refactor code into smaller, better-organized modules
* Reduce over-usage methods when simple helper functions would do
* Separate database abstraction a little more cleanly so that it could be more easily be turned into a trait later. This would allow other backing stores besides CSV files.
* Some very small amount of unit testing
* Print out the total number of requests made when the program is finished running

#### Results

The total number of requests made for my data after the initial program run went down ~3x 🚀

