### PR TITLE
Provide instructions for sniffing NYT token

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,39 @@ $ cargo run --release -- -t <your NYT token> -s 2016-01-01 -q 10 -o data.csv
 
 The NYT subscription token must be extracted via your browser (see below).
 
-The program will fetch results concurrently, but by default, requests are limited to 5 per second to reduce the load on NYT's servers.
-While you can choose to override that limit to speed up the search, be nice and use something reasonable.
-There shouldn't be any need to run this script very often so it's better to just err on the side of being slow.
-Regardless of the setting you use, default or not, I'm not responsible for anything that happens to your account.
+The program will fetch results concurrently, but by default, requests are limited to 5 per second to
+reduce the load on NYT's servers. While you can choose to override that limit to speed up the
+search, be nice and use something reasonable. There shouldn't be any need to run this script very
+often so it's better to just err on the side of being slow. Regardless of the setting you use,
+default or not, I'm not responsible for anything that happens to your account.
 
 ### Design goals
 
 1. Reduce requests made to NYT's servers. If provided, data from previous runs is loaded and used to
 avoid re-requesting information pulled from previous runs.
-2. Reduce load on NYT's servers. Requests made to the server are rate-limited.
-3. Maximum concurrency. Requests are made as concurrently as possible given the other two
+1. Reduce load on NYT's servers. Requests made to the server are rate-limited.
+1. Maximum concurrency. Requests are made as concurrently as possible given the other two
 constraints thanks to async/await. It's totally overkill with the default amount of rate-limiting 🤷🏽‍♂
+
+### Extracting your subscription token
+
+These instructions are for Google Chrome, but you should be able to do the equivalent with other
+browsers' developer tools.
+
+1. Open the Developer Tools dialog
+1. Open the Network tab
+1. Navigate to <https://www.nytimes.com/crosswords>
+1. Look for a request for some kind of json file e.g. `progress.json`, `mini-stats.json`, or
+`stats-and-streaks.json`.
+1. In the headers pane, find the value of `nyt-s` in the list of request headers. That is your
+token. If you can't find the `nyt-s` header in the request, try a different json file.
 
 ### Under the hood
 
-The script scrapes data using some undocumented but public REST APIs used by the official NYT crossword webpage.
-The APIs can be found by using the included set of developer tools in Chrome or Firefox to peek at HTTP traffic while browsing the crossword webpage.
+The script scrapes data using some undocumented but public REST APIs used by the official NYT
+crossword webpage.
+The APIs can be found by using the included set of developer tools in Chrome or Firefox to peek at
+HTTP traffic while browsing the crossword webpage.
 
 Some details if you want to bypass the script and replicate the functionality yourself:
 
@@ -81,29 +97,29 @@ to know that id. To find it, send a GET request as below, specifying `{start_dat
 in YYYY-MM-DD format ([ISO 8601](https://xkcd.com/1179)). The server response is limited to 100
 puzzles and can be limited further by adding a `limit` parameter.
 
-```sh
-curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v3/36569100/puzzles.json?publish_type=daily&date_start={start_date}&date_end={end_date}' -H 'accept: application/json'
-```
+    ```sh
+    curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v3/36569100/puzzles.json?publish_type=daily&date_start={start_date}&date_end={end_date}' -H 'accept: application/json'
+    ```
 
-2. To fetch solve stats for a given puzzle, send a GET request as below, replacing `{id}` with the
+1. To fetch solve stats for a given puzzle, send a GET request as below, replacing `{id}` with the
 puzzle id. This API requires a NYT crossword subscription. `{subscription_header}` can be found by
 snooping on outgoing HTTP requests via Chrome/Firefox developer tools while opening a NYT crossword
 in your browser. Alternatively, you can supposedly extract your session cookie from your browser and
 send that instead (see linked reddit post below), but I haven't tried it myself.
+  
+    ```sh
+    curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' -H 'nyt-s: {subscription_header}'
+    ```
 
-```sh
-curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' -H 'nyt-s: {subscription_header}'
-```
-
-4. Check out the `calcs` and `firsts` field of this response to get information like solve duration,
+1. Check out the `calcs` and `firsts` field of this response to get information like solve duration,
 when the puzzle was solved, and whether any assists were used.
 
-5. Rinse and repeat, collecting data for the dates of interest.
+1. Rinse and repeat, collecting data for the dates of interest.
 
 ## Plotting the data
 
-Use your favorite tools to analyze and plot the raw data stored in the CSV file. The Python-pandas-matplotlib trifecta
-works great.
+Use your favorite tools to analyze and plot the raw data stored in the CSV file. The
+Python-pandas-matplotlib trifecta works great.
 
 My plots are generated via the Python script in the [plot](./plot) folder. To use it, run the following:
 
@@ -115,7 +131,7 @@ $ pip3 install -r plot/requirements.txt
 $ plot/plot.py <path to csv file> <path to save plot image>
 ```
 
-The output path can be an SVG or PNG file. 
+The output path can be an SVG or PNG file.
 
 ## Auto-updating
 
@@ -126,9 +142,12 @@ plotting scripts, and the whole thing is containerized and run via Google Cloud 
 
 ## References
 
-* [Relevant Reddit post](https://www.reddit.com/r/crossword/comments/dqtnca/my_automatic_nyt_crossword_downloading_script): for figuring out how to find the right APIs to hit
-* [Rex Parker does the NY Times crossword](https://rexwordpuzzle.blogspot.com): grumpy old man
+* [Relevant Reddit post][1]: for figuring out how to find the right APIs to hit
+* [Rex Parker does the NY Times crossword][2]: grumpy old man
 
 ## Disclaimer
 
 This is not an officially supported Google product
+
+[1]: https://www.reddit.com/r/crossword/comments/dqtnca/my_automatic_nyt_crossword_downloading_script
+[2]: https://rexwordpuzzle.blogspot.com


### PR DESCRIPTION
* Add in-depth instructions for sniffing your NYT subscription token using Google Chrome
* Perform some general Markdown cleanup in README

Fixes #6