### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: stable
           components: clippy, rustfmt
-          override: true
     - name: rustfmt
-      uses: mbrobbel/rustfmt-check@0.2.0
+      uses: mbrobbel/rustfmt-check@0.7.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: clippy
-      uses: actions-rs/clippy-check@v1.0.5
+      uses: clechasseur/rs-clippy-check@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build


### PR DESCRIPTION
Use newer, non-abandoned GitHub Actions to unbreak the build and use Node 16