### PR TITLE
Fix broken API calls to NYT endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ in YYYY-MM-DD format ([ISO 8601](https://xkcd.com/1179)). The server response is
 puzzles and can be limited further by adding a `limit` parameter.
 
     ```sh
-    curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v3/36569100/puzzles.json?publish_type=daily&date_start={start_date}&date_end={end_date}' -H 'accept: application/json'
+    curl 'https://www.nytimes.com/svc/crosswords/v3/36569100/puzzles.json?publish_type=daily&date_start={start_date}&date_end={end_date}' -H 'accept: application/json'
     ```
 
 1. To fetch solve stats for a given puzzle, send a GET request as below, replacing `{id}` with the
@@ -108,7 +108,7 @@ in your browser. Alternatively, you can supposedly extract your session cookie f
 send that instead (see linked reddit post below), but I haven't tried it myself.
   
     ```sh
-    curl 'https://nyt-games-prd.appspot.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' -H 'nyt-s: {subscription_header}'
+    curl 'https://www.nytimes.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' -H 'nyt-s: {subscription_header}'
     ```
 
 1. Check out the `calcs` and `firsts` field of this response to get information like solve duration,

--- a/plot/plot.py
+++ b/plot/plot.py
@@ -48,7 +48,7 @@ def parse_data(csv_path):
     solve_time_secs
     weekday
     """
-    df = pd.read_csv(csv_path, parse_dates=["date"], index_col="date")
+    df = pd.read_csv(csv_path, parse_dates=["date"])
     df["Solved datetime"] = pd.to_datetime(df["solved_unix"], unit="s")
     # Use the date solved rather than the puzzle date as the index.
     # Puzzle date is interesting for analyzing puzzle difficulty over time (but skewed by change
@@ -74,6 +74,7 @@ def parse_data(csv_path):
 def save_plot(df, out_path, ymax):
     fig = plt.figure(figsize=(10, 7), dpi=200)
     today = datetime.date.today().isoformat()
+    latest_solve = df['date'].sort_values()[-1].date().isoformat()
     plt.title(
         f"NYT crossword solve time (8-week rolling average) as of {today}"
     )
@@ -85,7 +86,7 @@ def save_plot(df, out_path, ymax):
         )
     plt.legend()
 
-    ax.set_xlabel("Solve Date")
+    ax.set_xlabel(f"Solve Date (latest: {latest_solve})")
     ax.set_ylabel("Minutes")
     minor_yticks = np.arange(0, ymax + 1, 5)
     ax.set_ylim(0, ymax)

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -106,7 +106,7 @@ pub struct RateLimitedClient {
 }
 
 impl RateLimitedClient {
-    const API_BASE: &'static str = "https://nyt-games-prd.appspot.com/svc/crosswords";
+    const API_BASE: &'static str = "https://www.nytimes.com/svc/crosswords";
     const PUZZLE_INFO_ENDPOINT: &'static str =
         "/v3/36569100/puzzles.json?publish_type=daily&date_start={start_date}&date_end={end_date}";
     const PUZZLE_STATS_ENDPOINT: &'static str = "/v6/game/{id}.json";


### PR DESCRIPTION
The base endpoint for the NY Times API changed, breaking all API calls.

* Update the URL
* Add a small note to the generated plot indicating the last solved puzzle, which will help make this a little easier to spot next time.

h/t redditor [brendanl79](https://www.reddit.com/r/crossword/comments/16uk92h/nyt_crossword_api_endpoint_downmoved/) for the fix.

Fixes #9 