### PR TITLE
update to use cookies instead of headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ browsers' developer tools.
 1. Navigate to <https://www.nytimes.com/crosswords>
 1. Look for a request for some kind of json file e.g. `progress.json`, `mini-stats.json`, or
 `stats-and-streaks.json`.
-1. In the headers pane, find the value of `nyt-s` in the list of request headers. That is your
-token. If you can't find the `nyt-s` header in the request, try a different json file.
+1. In the headers pane, find the list of cookies, and fine `NYT-S` in that string. That is your
+token. If you can't find the `NYT-S` cookie in the request, try a different json file.
 
 ### Under the hood
 
@@ -108,7 +108,7 @@ in your browser. Alternatively, you can supposedly extract your session cookie f
 send that instead (see linked reddit post below), but I haven't tried it myself.
   
     ```sh
-    curl 'https://www.nytimes.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' -H 'nyt-s: {subscription_header}'
+    curl 'https://www.nytimes.com/svc/crosswords/v6/game/{id}.json' -H 'accept: application/json' --cookie 'NYT-S={subscription_header}'
     ```
 
 1. Check out the `calcs` and `firsts` field of this response to get information like solve duration,

--- a/plot/plot.py
+++ b/plot/plot.py
@@ -25,7 +25,6 @@ import seaborn as sns
 DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 YEAR_TO_SPLIT = datetime.datetime.now().year - 1
-YEAR_TO_SPLIT_STR = str(YEAR_TO_SPLIT)
 
 A = argparse.ArgumentParser(
     description='Generates plots of crossword statistics from a CSV',
@@ -35,7 +34,7 @@ A.add_argument('in_file', action='store', type=str,
     help="The path to a CSV file generated from the crossword crate")
 A.add_argument('out_file', action='store', type=str,
     help="The output path where plots should be saved (e.g. trends.png)")
-A.add_argument('-c', '--ceiling', action='store', type=int, default=0,
+A.add_argument('-c', '--ceiling', action='store', type=int, default=None,
     help='Max Y Value in minutes; use 0 to compute from data.')
 A.add_argument('-s', '--style', action='store', default="Solarize_Light2",
     type=str,  # choices=plt.style.available,  # looks gross
@@ -135,9 +134,9 @@ def save_split_vln_plot(df, out_path, ymax):
         ceiling: max y-value to show
     """
     df['solve_time_m'] = df['solve_time_secs'] / 60.0
-    df['In ' + YEAR_TO_SPLIT_STR] = df['Solved datetime'] > datetime.datetime(YEAR_TO_SPLIT, 1, 1)
+    df[f'In {YEAR_TO_SPLIT}'] = df['Solved datetime'] > datetime.datetime(YEAR_TO_SPLIT, 1, 1)
     try:
-        ax = sns.violinplot(x="weekday", y="solve_time_m", hue='In ' + YEAR_TO_SPLIT_STR,
+        ax = sns.violinplot(x="weekday", y="solve_time_m", hue=f'In {YEAR_TO_SPLIT}',
                             split=True, data=df, bw=.25, order=DAYS)
     except:
         # Happens if there is no data from last year
@@ -153,7 +152,7 @@ def save_split_vln_plot(df, out_path, ymax):
 
     ax.legend()  # Seems to have the effect of removing the title of the legend
     handles, labels = ax.get_legend_handles_labels()
-    ax.legend(handles, ["Before " + YEAR_TO_SPLIT_STR, YEAR_TO_SPLIT_STR + "+"], loc="upper left")
+    ax.legend(handles, [f"Before {YEAR_TO_SPLIT}", f"{YEAR_TO_SPLIT}+"], loc="upper left")
 
     plt.savefig(out_path)
     plt.close()
@@ -162,7 +161,7 @@ def save_split_vln_plot(df, out_path, ymax):
 def generate(in_file, out_file, ceiling = None):
     df = parse_data(in_file)
 
-    if not ceiling:
+    if ceiling is None:
         # Pick an appropriate y-axis, balancing being robust to outliers vs. showing all data
         ymax = df["solve_time_secs"].quantile(0.99) / 60
     else:

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -20,7 +20,7 @@ use governor::state::direct::NotKeyed;
 use governor::state::InMemoryState;
 use governor::{Quota, RateLimiter};
 use log::error;
-use reqwest::header::{self, HeaderMap};
+use reqwest::header::{self, HeaderMap, HeaderValue};
 use reqwest::IntoUrl;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -119,9 +119,9 @@ impl RateLimitedClient {
     /// * `quota` - Outgoing request quota in requests per second
     pub fn new(nyt_s: &str, quota: NonZeroU32) -> Self {
         let mut headers = HeaderMap::new();
-        headers.insert("nyt-s", nyt_s.parse().unwrap());
         headers.insert(header::ACCEPT, "application/json".parse().unwrap());
         headers.insert(header::DNT, "1".parse().unwrap());
+        headers.insert(header::COOKIE, HeaderValue::from_str(&format!("NYT-S={}", nyt_s)).unwrap());
 
         let client = reqwest::ClientBuilder::new()
             .user_agent("Scraping personal stats")

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -121,7 +121,13 @@ impl RateLimitedClient {
         let mut headers = HeaderMap::new();
         headers.insert(header::ACCEPT, "application/json".parse().unwrap());
         headers.insert(header::DNT, "1".parse().unwrap());
-        headers.insert(header::COOKIE, HeaderValue::from_str(&format!("NYT-S={}", nyt_s)).unwrap());
+        if nyt_s.len() == 162 {
+            headers.insert(header::COOKIE, HeaderValue::from_str(&format!("NYT-S={}", nyt_s)).unwrap());
+        } else if nyt_s.len() == 142 {
+            headers.insert("nyt-s", nyt_s.parse().unwrap());
+        } else {
+            panic!("NYT-S must be either 162 characters (for NYT-S cookie) or 142 characters (for nyt-s header)");
+        }
 
         let client = reqwest::ClientBuilder::new()
             .user_agent("Scraping personal stats")


### PR DESCRIPTION
It seems that nyt-s is now a cookie (and capitalized), not a header.

I don't know if this is universally rolled out, but the previous code doesn't work for my account, and this does. I assume this will work for everyone, but please do verify it still works for you.

Commit 1: The primary bugfix
Commit 2: Little changes to the plotly file to dynamically select a split year, to handle a `0` as the ceiling (which is what argparse provides on my machine I think), and to handle no data before the split year