### PR TITLE
Replace brittle subscription token heuristic with explicit args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossword"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Kesavan Yogeswaran <hikes@google.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
We support subscription tokens in two formats:
* A string pulled from the NYT-S cookie. This is the recommended path.
* A string pulled from the nyt-s HTTP header. While it appears that this header is no longer used, it still works with the NYT API and my old header-based token still works, so this is still supported.

Previously, we used a brittle heuristic based on string length to determine whether a passed in token was a header or a cookie. This is now broken, as cookies are not a set length.

Instead, force the user to specify via CLI arg what kind of token they're passing in. Since most people are probably using a cookie at this point, the old `-t` short arg is mapped to the cookie-based token.

Fixes #17 